### PR TITLE
Changes to headless chromium, part of the main chromium package but not yet released.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Name  | About  | Supported Languages | License
 Name  | About  | Supported Languages | License
 :------------ |:---------------| :----- | :-----------
 |[Awesomium](http://www.awesomium.com/) | Chromium-based headless browser engine|C++, .NET| Free/Commercial |
-|[Headless Chromium](https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md) | Headless Chromium is a library for running Chromium in a headless/server environment.|C++| Not Specified |
+|[Headless Chromium](https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md) | Chromium feature activated with the `--headlesss` flag, currently availible in the nightly build of Chromium, not yet released|C++| Opensource |
 
 ## Webkit drivers
 


### PR DESCRIPTION
Updated the README to reflect that headless chromium is part of the main project and not a seperate library for controlling chromium.

It stops the browser from requiring the X11 server, and is availible by downloading the latest nightly build
