### PR TITLE
Add Lightpanda headless browser Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,19 @@ Headless Browsers
 *A web browser without a graphical user interface, controlled programmatically. Used for automation, testing, and other purposes.*
 
 ## Browser engines
-
-*These browser engines fully render web pages or run JavaScript in a virtual DOM*
-
-Name  | About  | Supported Languages | License
-:------------ |:---------------| :----- | :-----------
-|[Chromium Embedded Framework](https://bitbucket.org/chromiumembedded/cef) |CEF is a open source project based on the Google Chromium project.        |   JavaScript | BSD |
-|[Erik](https://github.com/phimage/Erik) | Headless browser on top of Kanna and WebKit.|Swift| MIT |
-|[jBrowserDriver](https://github.com/machinepublishers/jbrowserdriver) | A Selenium-compatible headless browser which is written in pure Java. WebKit-based. Works with any of the Selenium Server bindings.|Java| Apache License v2.0 |
-|[PhantomJS](http://phantomjs.org/) | [[Unmaintained]](https://groups.google.com/forum/#!topic/phantomjs/9aI5d-LDuNE) PhantomJS is a headless WebKit scriptable with a JavaScript API. It has fast and native support for various web standards: DOM handling, CSS selector, JSON, Canvas, and SVG. | JavaScript, Python, Ruby, Java, C#, Haskell, Objective-C, Perl, PHP, R(via [Selenium](http://docs.seleniumhq.org/about/platforms.jsp#programming-languages))  | BSD 3-Clause |
-|[Splash](https://github.com/scrapinghub/splash) | Splash is a javascript rendering service with an HTTP API. It's a lightweight browser with an HTTP API, implemented in Python using Twisted and QT.|Any| BSD 3-Clause |
-|[Surf](https://github.com/headzoo/surf)|Surf is an open source project that implements a virtual web browser that can be controlled programatically | Go | MIT
-
+ 
+ *These browser engines fully render web pages or run JavaScript in a virtual DOM*
+ 
+ | Name | About | Supported Languages | License |
+ | --- | --- | --- | --- |
+ | [Chromium Embedded Framework](https://bitbucket.org/chromiumembedded/cef) | CEF is a open source project based on the Google Chromium project. | JavaScript | BSD |
+ | [Erik](https://github.com/phimage/Erik) | Headless browser on top of Kanna and WebKit. | Swift | MIT |
+ | [jBrowserDriver](https://github.com/machinepublishers/jbrowserdriver) | A Selenium-compatible headless browser which is written in pure Java. WebKit-based. Works with any of the Selenium Server bindings. | Java | Apache License v2.0 |
++| [Lightpanda](https://github.com/lightpanda-io/browser) | A headless browser built from scratch for AI and automation. Features 11x faster execution and 9x lower memory usage than Chrome. Supports CDP protocol for Puppeteer/Playwright compatibility. | Zig | AGPL-3.0 |
+ | [PhantomJS](http://phantomjs.org/) | [[Unmaintained]](https://groups.google.com/forum/#!topic/phantomjs/9aI5d-LDuNE) PhantomJS is a headless WebKit scriptable with a JavaScript API. It has fast and native support for various web standards: DOM handling, CSS selector, JSON, Canvas, and SVG. | JavaScript, Python, Ruby, Java, C#, Haskell, Objective-C, Perl, PHP, R(via [Selenium](http://docs.seleniumhq.org/about/platforms.jsp#programming-languages)) | BSD 3-Clause |
+ | [Splash](https://github.com/scrapinghub/splash) | Splash is a javascript rendering service with an HTTP API. It's a lightweight browser with an HTTP API, implemented in Python using Twisted and QT. | Any | BSD 3-Clause |
+ | [Surf](https://github.com/headzoo/surf) | Surf is an open source project that implements a virtual web browser that can be controlled programatically | Go | MIT |
+ 
 ## Multi drivers
 
 *These libraries can control multiple browser engines (typically using Selenium)*


### PR DESCRIPTION
Adding Lightpanda, a high-performance headless browser built from scratch in Zig, specifically designed for AI agents and web automation. Key features:

Built from scratch (not a Chromium fork)
11x faster execution than Chrome headless
9x lower memory usage than Chrome headless
CDP protocol support (works with Puppeteer/Playwright) Purpose-built for headless operation without rendering overhead