### PR TITLE
Fix Headless Chromium README entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Name  | About  | Supported Languages | License
 Name  | About  | Supported Languages | License
 :------------ |:---------------| :----- | :-----------
 |[Awesomium](http://www.awesomium.com/) | Chromium-based headless browser engine|C++, .NET| Free/Commercial |
-|[Headless Chromium](https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md) | Chromium feature activated with the `--headlesss` flag, currently availible in the nightly build of Chromium, not yet released|C++| Opensource |
+|[Headless Chromium](https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md) | Chromium feature activated with the `--headless` flag, available since Chrome 59|C++| Opensource |
 |[Puppeteer](https://github.com/GoogleChrome/puppeteer) | Headless Chrome Node API from the Chrome DevTools team|JavaScript| Apache |
 |[PuppeteerSharp](https://github.com/kblok/puppeteer-sharp) | PuppeteerSharp is a .NET port of the official Headless Chrome Node.JS Puppeteer API|.NET| MIT |
 |[chrome-remote-interface](https://github.com/cyrus-and/chrome-remote-interface) | Chrome Debugging Protocol interface for Node.js|JavaScript| MIT |


### PR DESCRIPTION
## Summary

- correct the Headless Chromium flag to `--headless`
- update the stale release status to note availability since Chrome 59

## Validation

- checked current Chrome Headless documentation and Chromium Headless README for the `--headless` flag
- checked Chrome's Headless launch documentation for Chrome 59 availability
- `git diff --check`
- `git diff --cached --check`

Closes #111