### PR TITLE
Add Browserless to Browser engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Name  | About  | Supported Languages | License
 |[PhantomJS](http://phantomjs.org/) | [[Unmaintained]](https://groups.google.com/forum/#!topic/phantomjs/9aI5d-LDuNE) PhantomJS is a headless WebKit scriptable with a JavaScript API. It has fast and native support for various web standards: DOM handling, CSS selector, JSON, Canvas, and SVG. | JavaScript, Python, Ruby, Java, C#, Haskell, Objective-C, Perl, PHP, R(via [Selenium](http://docs.seleniumhq.org/about/platforms.jsp#programming-languages))  | BSD 3-Clause |
 |[Splash](https://github.com/scrapinghub/splash) | Splash is a javascript rendering service with an HTTP API. It's a lightweight browser with an HTTP API, implemented in Python using Twisted and QT.|Any| BSD 3-Clause |
 |[Surf](https://github.com/headzoo/surf)|Surf is an open source project that implements a virtual web browser that can be controlled programatically | Go | MIT
+|[Browserless](https://github.com/browserless/browserless) | Self-hostable open-source service that exposes headless Chrome over a WebSocket and HTTP API, letting Puppeteer and Playwright connect to remote browsers, with REST endpoints for scraping, screenshots, and PDFs. Also offered as a hosted API. |JavaScript, Python, others (via Puppeteer & Playwright bindings)| SSPL-1.0 / Commercial |
 
 ## Multi drivers
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Headless Browsers
 
 Name  | About  | Supported Languages | License
 :------------ |:---------------| :----- | :-----------
+|[Browserless](https://github.com/browserless/browserless) | Self-hostable open-source service that exposes headless Chrome over a WebSocket and HTTP API, letting Puppeteer and Playwright connect to remote browsers, with REST endpoints for scraping, screenshots, and PDFs. Also offered as a hosted API. |JavaScript, Python, others (via Puppeteer & Playwright bindings)| SSPL-1.0 / Commercial |
 |[Chromium Embedded Framework](https://bitbucket.org/chromiumembedded/cef) |CEF is a open source project based on the Google Chromium project.        |   JavaScript | BSD |
 |[Erik](https://github.com/phimage/Erik) | Headless browser on top of Kanna and WebKit.|Swift| MIT |
 |[jBrowserDriver](https://github.com/machinepublishers/jbrowserdriver) | A Selenium-compatible headless browser which is written in pure Java. WebKit-based. Works with any of the Selenium Server bindings.|Java| Apache License v2.0 |
 |[PhantomJS](http://phantomjs.org/) | [[Unmaintained]](https://groups.google.com/forum/#!topic/phantomjs/9aI5d-LDuNE) PhantomJS is a headless WebKit scriptable with a JavaScript API. It has fast and native support for various web standards: DOM handling, CSS selector, JSON, Canvas, and SVG. | JavaScript, Python, Ruby, Java, C#, Haskell, Objective-C, Perl, PHP, R(via [Selenium](http://docs.seleniumhq.org/about/platforms.jsp#programming-languages))  | BSD 3-Clause |
 |[Splash](https://github.com/scrapinghub/splash) | Splash is a javascript rendering service with an HTTP API. It's a lightweight browser with an HTTP API, implemented in Python using Twisted and QT.|Any| BSD 3-Clause |
 |[Surf](https://github.com/headzoo/surf)|Surf is an open source project that implements a virtual web browser that can be controlled programatically | Go | MIT
-|[Browserless](https://github.com/browserless/browserless) | Self-hostable open-source service that exposes headless Chrome over a WebSocket and HTTP API, letting Puppeteer and Playwright connect to remote browsers, with REST endpoints for scraping, screenshots, and PDFs. Also offered as a hosted API. |JavaScript, Python, others (via Puppeteer & Playwright bindings)| SSPL-1.0 / Commercial |
 
 ## Multi drivers
 


### PR DESCRIPTION
Adds **Browserless** as a new row in the *Browser engines* table, following the Splash precedent (a rendering/automation service exposed over an HTTP API, rather than a client-side driver library).

Browserless is a self-hostable open-source service that exposes headless Chrome over a WebSocket and HTTP API — Puppeteer and Playwright connect to remote browsers, with REST endpoints for scraping, screenshots, and PDFs. A hosted API is also available. Canonical open-source repo: https://github.com/browserless/browserless

- **Supported Languages:** JavaScript, Python, others (via Puppeteer & Playwright bindings)
- **License:** SSPL-1.0 / Commercial (dual-licensed, verified from the repo's LICENSE)

It's an actively maintained, established project (well over six months old). Single row appended to the end of the table.